### PR TITLE
Incorporate changes from PyTorch 1.3 and allow non-square fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-torch>=1.1.0
+torch>=1.3.0
 setuptools>=34.0.0
-


### PR DESCRIPTION
Will no longer work with earlier PyTorch versions.