### PR TITLE
Extend voting to use set of prior weights

### DIFF
--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -940,14 +940,18 @@ class DisplacementField(torch.Tensor):
         return voting.vote(self, softmin_temp, blur_sigma, subset_size)
 
     @wraps(voting.vote)
-    def get_vote_weights_with_variances(self, var, softmin_temp=1, blur_sigma=1, 
-                                        subset_size=None):
-        return voting.get_vote_weights_with_variances(self, var, softmin_temp, blur_sigma, 
-                                                      subset_size)
+    def get_vote_weights_with_variances(
+        self, var, softmin_temp=1, blur_sigma=1, subset_size=None
+    ):
+        return voting.get_vote_weights_with_variances(
+            self, var, softmin_temp, blur_sigma, subset_size
+        )
 
     @wraps(voting.vote)
     def vote_with_variances(self, var, softmin_temp=1, blur_sigma=1, subset_size=None):
-        return voting.vote_with_variances(self, var, softmin_temp, blur_sigma, subset_size)
+        return voting.vote_with_variances(
+            self, var, softmin_temp, blur_sigma, subset_size
+        )
 
 
 class set_identity_mapping_cache():

--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -924,6 +924,10 @@ class DisplacementField(torch.Tensor):
         return voting.get_vote_shape(self)
 
     @wraps(voting.vote)
+    def get_subset_size(self, subset_size=None):
+        return voting.get_subset_size(self, subset_size)
+
+    @wraps(voting.vote)
     def get_vote_subsets(self, subset_size=None):
         return voting.get_vote_subsets(self, subset_size)
 
@@ -934,6 +938,17 @@ class DisplacementField(torch.Tensor):
     @wraps(voting.vote)
     def vote(self, softmin_temp=1, blur_sigma=1, subset_size=None):
         return voting.vote(self, softmin_temp, blur_sigma, subset_size)
+
+    @wraps(voting.vote)
+    def get_vote_weights_with_variances(self, var, softmin_temp=1, blur_sigma=1, 
+                                        subset_size=None):
+        return voting.get_vote_weights_with_variances(self, var, softmin_temp, blur_sigma, 
+                                                      subset_size)
+
+    @wraps(voting.vote)
+    def vote_with_variances(self, var, softmin_temp=1, blur_sigma=1, subset_size=None):
+        return voting.vote_with_variances(self, var, softmin_temp, blur_sigma, subset_size)
+
 
 class set_identity_mapping_cache():
     """Context-manager that controls caching of identity_mapping() results.

--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -920,6 +920,18 @@ class DisplacementField(torch.Tensor):
         return voting.gaussian_blur(self, sigma, kernel_size)
 
     @wraps(voting.vote)
+    def get_vote_shape(self):
+        return voting.get_vote_shape(self)
+
+    @wraps(voting.vote)
+    def get_vote_subsets(self):
+        return voting.get_vote_subsets(self)
+
+    @wraps(voting.vote)
+    def get_vote_weights(self, softmin_temp=1, blur_sigma=1):
+        return voting.get_vote_weights(self, softmin_temp, blur_sigma)
+
+    @wraps(voting.vote)
     def vote(self, softmin_temp=1, blur_sigma=1):
         return voting.vote(self, softmin_temp, blur_sigma)
 

--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -924,16 +924,16 @@ class DisplacementField(torch.Tensor):
         return voting.get_vote_shape(self)
 
     @wraps(voting.vote)
-    def get_vote_subsets(self):
-        return voting.get_vote_subsets(self)
+    def get_vote_subsets(self, subset_size=None):
+        return voting.get_vote_subsets(self, subset_size)
 
     @wraps(voting.vote)
-    def get_vote_weights(self, softmin_temp=1, blur_sigma=1):
-        return voting.get_vote_weights(self, softmin_temp, blur_sigma)
+    def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
+        return voting.get_vote_weights(self, softmin_temp, blur_sigma, subset_size)
 
     @wraps(voting.vote)
-    def vote(self, softmin_temp=1, blur_sigma=1):
-        return voting.vote(self, softmin_temp, blur_sigma)
+    def vote(self, softmin_temp=1, blur_sigma=1, subset_size=None):
+        return voting.vote(self, softmin_temp, blur_sigma, subset_size)
 
 class set_identity_mapping_cache():
     """Context-manager that controls caching of identity_mapping() results.

--- a/torchfields/test_voting.py
+++ b/torchfields/test_voting.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+import torchfields
+
+def test_vote_shape():
+    assert(False)
+
+def test_voting_subsets():
+    assert(False)
+
+def test_voting_weights():
+    assert(False)
+
+def test_vote():
+    assert(False)
+
+def test_vote_with_variances():
+    f = torch.zeros((2,2,1,1)).field()
+    f[1] = 1
+    v = torch.zeros((2,1,1,1))
+    vf = f.vote_with_variances(var=v, softmin_temp=1, blur_sigma=0, subset_size=1)
+    tf = torch.ones((1,2,1,1)).field() / 2.
+    assert(torch.equal(tf, vf))
+    v[1] = 1
+    # softmin_temp root of (e^(-sqrt(2)/x))/(e^(-sqrt(2)/x)+e^(0/x))-0.25=0
+    vf = f.vote_with_variances(var=v, softmin_temp=1.28727, blur_sigma=0, subset_size=1)
+    tf = torch.ones((1,2,1,1)).field() / 4.
+    assert(torch.allclose(tf, vf))
+
+    

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -3,7 +3,7 @@ import torch.nn.functional as F
 
 
 ############################
-# Vector voting implemtation
+# Vector vote implemtation
 ############################
 
 def gaussian_blur(self, sigma=1, kernel_size=5):
@@ -27,6 +27,73 @@ def gaussian_blur(self, sigma=1, kernel_size=5):
     kernel = kernel.expand(2, 1, *kernel.shape)
     return F.conv2d(padded, weight=kernel, groups=2)
 
+def get_vote_shape(self):
+    """Consistently split shape into N fields & shape of field
+    """
+    n, _, *shape = self.shape
+    return n, shape
+
+def get_vote_subsets(self):
+    """Compute list of majority subsets to use in vote
+    """
+    n, _ = self.get_vote_shape()
+    m = (n + 1) // 2  # smallest number that constututes a majority
+    from itertools import combinations
+    mtuples = list(combinations(range(n), m))
+    return mtuples
+
+def get_vote_weights(self, softmin_temp=1, blur_sigma=1):
+    """Calculate softmin weights for batch of displacement fields, indicating 
+    which fields should be considered consensus.
+
+    Args:
+        self: DisplacementField of shape (N, 2, H, W)
+        softmin_temp (float): temperature of softmin to use
+        blur_sigma (float): std dev of the Gaussian kernel by which to blur
+            the softmin inputs. Note that the outputs are not blurred.
+            None or 0 means no blurring.
+
+    Returns:
+        softmin numerator (torch.Tensor): (N, 1, H, W)
+        softmin denominator (torch. Tensor): (N, 1, H, W)
+    """
+    from itertools import combinations
+    if self.ndimension() != 4:
+        raise ValueError('Vector vote is only implemented on '
+                         'displacement fields with 4 dimensions. '
+                         'The input has {}.'.format(self.ndimension()))
+    n, shape = self.get_vote_shape()
+    if n == 1:
+        return self 
+    elif n % 2 == 0:
+        raise ValueError('Cannot vetor vote on an even number of '
+                         'displacement fields: {}'.format(n))
+    blurred = self.gaussian_blur(sigma=blur_sigma) if blur_sigma else self
+    mtuples = self.get_vote_subsets()
+
+    # compute distances for all pairs of fields
+    dists = torch.zeros((n, n, *shape)).to(device=blurred.device)
+    for i in range(n):
+        for j in range(i):
+            dists[i, j] = dists[j, i] \
+                = blurred[i].distance(blurred[j])
+
+    # compute mean distance for all majority tuples
+    mtuple_avg = []
+    for mtuple in mtuples:
+        delta = torch.stack([
+            dists[i, j] for i, j in combinations(mtuple, 2)
+        ]).mean(dim=0)
+        mtuple_avg.append(delta)
+    mavg = torch.stack(mtuple_avg)
+
+    # compute weights for mtuples: smaller mean distance -> higher weight
+    # computing softmin explicitly for access to numerator & denominator
+    # equivalent to:
+    # (-mavg/softmin_temp).softmax(dim=0) == weights_num / weight_den
+    weights_num = torch.exp(-mavg/softmin_temp)
+    weights_den = weights_num.sum(dim=0, keepdim=True)
+    return weights_num, weights_den
 
 def vote(self, softmin_temp=1, blur_sigma=1):
     """Produce a single, consensus displacement field from a batch of
@@ -46,66 +113,19 @@ def vote(self, softmin_temp=1, blur_sigma=1):
 
     Returns:
         DisplacementField of shape (1, 2, H, W) containing the vector
-        voting result
+        vote result
     """
-    field_weights = get_field_weights(self, 
-                                      softmin_temp=softmin_temp,
-                                      blur_sigma=blur_sigma)
-    partition = field_weights.sum(dim=0, keepdim=True)
-    field_weights = field_weights / partition
-    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
-
-def get_field_weights(field, softmin_temp=1, blur_sigma=1):
-    """Calculate softmin weights for set of fields, indicating which fields
-    should be considered consensus.
-
-    Args:
-        field: DisplacementField of shape (N, 2, H, W)
-        softmin_temp (float): temperature of softmin to use
-        blur_sigma (float): std dev of the Gaussian kernel by which to blur
-            the softmin inputs. Note that the outputs are not blurred.
-            None or 0 means no blurring.
-
-    Returns:
-        torch.Tensor of shape (N, 1, H, W) containing the field weights 
-    """
-    from itertools import combinations
-    if field.ndimension() != 4:
-        raise ValueError('Vector voting is only implemented on '
-                         'displacement fields with 4 dimensions. '
-                         'The input has {}.'.format(field.ndimension()))
-    n, _two_, *shape = field.shape
-    if n == 1:
-        return field
-    elif n % 2 == 0:
-        raise ValueError('Cannot vetor vote on an even number of '
-                         'displacement fields: {}'.format(n))
-    m = (n + 1) // 2  # smallest number that constututes a majority
-    blurred = field.gaussian_blur(sigma=blur_sigma) if blur_sigma else field
-
-    # compute distances for all pairs of fields
-    dists = torch.zeros((n, n, *shape)).to(device=blurred.device)
-    for i in range(n):
-        for j in range(i):
-            dists[i, j] = dists[j, i] \
-                = blurred[i].distance(blurred[j])
-
-    # compute mean distance for all m-tuples
-    mtuples = list(combinations(range(n), m))
-    mtuple_avg = []
-    for mtuple in mtuples:
-        delta = torch.stack([
-            dists[i, j] for i, j in combinations(mtuple, 2)
-        ]).mean(dim=0)
-        mtuple_avg.append(delta)
-    mavg = torch.stack(mtuple_avg)
-
-    # compute weights for mtuples: smaller mean distance -> higher weight
-    mt_weights = (-mavg/softmin_temp).softmax(dim=0)
-
+    n, shape = self.get_vote_shape()
+    mtuples = self.get_vote_subsets()
+    mt_num , mt_den = self.get_vote_weights(softmin_temp=softmin_temp,
+                                              blur_sigma=blur_sigma)
+    mt_weights = mt_num / mt_den 
     # assign mtuple weights back to individual fields
     field_weights = torch.zeros((n, *shape)).to(device=mt_weights.device)
     for i, mtuple in enumerate(mtuples):
         for j in mtuple:
             field_weights[j] += mt_weights[i]
-    return field_weights
+    # rather than use m, prefer sum for sum precision
+    elements_per_subset = field_weights.sum(dim=0, keepdim=True)
+    field_weights = field_weights / elements_per_subset
+    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -66,7 +66,7 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
                          'The input has {}.'.format(self.ndimension()))
     n, shape = self.get_vote_shape()
     if n == 1:
-        return self 
+        return torch.ones((1, *shape)) 
     # elif n % 2 == 0:
     #     raise ValueError('Cannot vetor vote on an even number of '
     #                      'displacement fields: {}'.format(n))

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -66,7 +66,9 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
                          'The input has {}.'.format(self.ndimension()))
     n, shape = self.get_vote_shape()
     if n == 1:
-        return torch.ones((1, *shape)) 
+        return torch.ones((1, *shape)).to(self)
+    elif n == 2:
+        return torch.ones((1, *shape)).to(self) / 2
     # elif n % 2 == 0:
     #     raise ValueError('Cannot vetor vote on an even number of '
     #                      'displacement fields: {}'.format(n))

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -48,19 +48,40 @@ def vote(self, softmin_temp=1, blur_sigma=1):
         DisplacementField of shape (1, 2, H, W) containing the vector
         voting result
     """
+    field_weights = get_field_weights(self, 
+                                      softmin_temp=softmin_temp,
+                                      blur_sigma=blur_sigma)
+    partition = field_weights.sum(dim=0, keepdim=True)
+    field_weights = field_weights / partition
+    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
+
+def get_field_weights(field, softmin_temp=1, blur_sigma=1):
+    """Calculate softmin weights for set of fields, indicating which fields
+    should be considered consensus.
+
+    Args:
+        field: DisplacementField of shape (N, 2, H, W)
+        softmin_temp (float): temperature of softmin to use
+        blur_sigma (float): std dev of the Gaussian kernel by which to blur
+            the softmin inputs. Note that the outputs are not blurred.
+            None or 0 means no blurring.
+
+    Returns:
+        torch.Tensor of shape (N, 1, H, W) containing the field weights 
+    """
     from itertools import combinations
-    if self.ndimension() != 4:
+    if field.ndimension() != 4:
         raise ValueError('Vector voting is only implemented on '
                          'displacement fields with 4 dimensions. '
-                         'The input has {}.'.format(self.ndimension()))
-    n, _two_, *shape = self.shape
+                         'The input has {}.'.format(field.ndimension()))
+    n, _two_, *shape = field.shape
     if n == 1:
-        return self
+        return field
     elif n % 2 == 0:
         raise ValueError('Cannot vetor vote on an even number of '
                          'displacement fields: {}'.format(n))
     m = (n + 1) // 2  # smallest number that constututes a majority
-    blurred = self.gaussian_blur(sigma=blur_sigma) if blur_sigma else self
+    blurred = field.gaussian_blur(sigma=blur_sigma) if blur_sigma else field
 
     # compute distances for all pairs of fields
     dists = torch.zeros((n, n, *shape)).to(device=blurred.device)
@@ -87,6 +108,4 @@ def vote(self, softmin_temp=1, blur_sigma=1):
     for i, mtuple in enumerate(mtuples):
         for j in mtuple:
             field_weights[j] += mt_weights[i]
-    field_weights = field_weights / field_weights.sum(dim=0, keepdim=True)
-
-    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
+    return field_weights


### PR DESCRIPTION
Allow each vector to be assigned an initial weight that can be taken into consideration during the voting procedure. This extension reduces to unweighted voting when weights are zero.

Vectors are treated as probability distributions, where the vector value is the mean, and the prior weight is the standard deviation. Subsets of vectors are combined into mixture distributions. The softmin function produces weights across the subsets using the variance of each mixture distribution.