### PR TITLE
fix: 1.7.0 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch>=1.3.0
+torch>=1.7.0
 setuptools>=34.0.0


### PR DESCRIPTION
As of version 1.7.0, methods on `torch.Tensor` and functions in public `torch.*` namespaces applied on `torch.Tensor` subclasses will return subclass instances instead of `torch.Tensor` instances.

*  `__torch_function__`: as suggested by @Quasimondo (thanks!)
*  `__bool__`: force `Tensor` return type to avoid infinite recursion

Fixes #7 