### PR TITLE
Include method to vote with distance-based weights

### DIFF
--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn.functional as F
 from functools import wraps
 
-from .utils import (permute_input, permute_output, ensure_dimensions)
+from .utils import permute_input, permute_output, ensure_dimensions
 from . import inversion
 from . import voting
 
@@ -12,6 +12,7 @@ from . import voting
 ####################################
 # DisplacementField Class Definition
 ####################################
+
 
 class DisplacementField(torch.Tensor):
     """An abstraction that encapsulates functionality of displacement fields
@@ -21,6 +22,7 @@ class DisplacementField(torch.Tensor):
     purposes, and also include additional functionality for composing
     displacements and sampling from tensors.
     """
+
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
         if kwargs is None:
@@ -36,16 +38,19 @@ class DisplacementField(torch.Tensor):
 
     def __init__(self, *args, **kwargs):
         if len(self.shape) < 3:
-            raise ValueError('The displacement field must have a components '
-                             'dimension. Only {} dimensions are present.'
-                             .format(len(self.shape)))
+            raise ValueError(
+                "The displacement field must have a components "
+                "dimension. Only {} dimensions are present.".format(len(self.shape))
+            )
         if self.shape[-3] != 2:
-            raise ValueError('The displacement field must have exactly 2 '
-                             'components, not {}.'.format(self.shape[-3]))
+            raise ValueError(
+                "The displacement field must have exactly 2 "
+                "components, not {}.".format(self.shape[-3])
+            )
 
     def __repr__(self, *args, **kwargs):
         out = super().__repr__(*args, **kwargs)
-        return out.replace('tensor', 'field', 1).replace('\n ', '\n')
+        return out.replace("tensor", "field", 1).replace("\n ", "\n")
 
     # Conversion to and from torch.Tensor
 
@@ -61,20 +66,26 @@ class DisplacementField(torch.Tensor):
         allowed_types = DisplacementField.__bases__
         if not isinstance(self, allowed_types):
             raise TypeError(
-                "'{}' cannot be converted to '{}'. Valid options are: {}"
-                .format(type(self).__name__, DisplacementField.__name__,
-                        [base.__module__ + "." + base.__name__
-                         for base in allowed_types]))
+                "'{}' cannot be converted to '{}'. Valid options are: {}".format(
+                    type(self).__name__,
+                    DisplacementField.__name__,
+                    [base.__module__ + "." + base.__name__ for base in allowed_types],
+                )
+            )
         if len(self.shape) < 3:
-            raise ValueError('The displacement field must have a components '
-                             'dimension. Only {} dimensions are present.'
-                             .format(len(self.shape)))
+            raise ValueError(
+                "The displacement field must have a components "
+                "dimension. Only {} dimensions are present.".format(len(self.shape))
+            )
         if self.shape[-3] != 2:
-            raise ValueError('The displacement field must have exactly 2 '
-                             'components, not {}.'.format(self.shape[-3]))
+            raise ValueError(
+                "The displacement field must have exactly 2 "
+                "components, not {}.".format(self.shape[-3])
+            )
         self.__class__ = DisplacementField
         self.__init__(*args, **kwargs)  # in case future __init__ is nonempty
         return self
+
     torch.Tensor.field_ = field_  # adds conversion to torch.Tensor superclass
     _from_superclass = field_  # for use in `return_subclass_type()`
 
@@ -84,8 +95,8 @@ class DisplacementField(torch.Tensor):
         if isinstance(data, torch.Tensor):
             return DisplacementField.field_(data.clone(), *args, **kwargs)
         else:
-            return DisplacementField.field_(
-                torch.tensor(data, *args, **kwargs).float())
+            return DisplacementField.field_(torch.tensor(data, *args, **kwargs).float())
+
     torch.Tensor.field = field  # adds conversion to torch.Tensor superclass
     torch.field = field
 
@@ -116,13 +127,14 @@ class DisplacementField(torch.Tensor):
         """
         if len(args) > 0 and isinstance(args[0], torch.Tensor):
             tensor_like, *args = args
-            if 'device' not in kwargs or kwargs['device'] is None:
-                kwargs['device'] = tensor_like.device
-            if 'size' not in kwargs or kwargs['size'] is None:
-                kwargs['size'] = tensor_like.shape
-            if 'dtype' not in kwargs or kwargs['dtype'] is None:
-                kwargs['dtype'] = tensor_like.dtype
+            if "device" not in kwargs or kwargs["device"] is None:
+                kwargs["device"] = tensor_like.device
+            if "size" not in kwargs or kwargs["size"] is None:
+                kwargs["size"] = tensor_like.shape
+            if "dtype" not in kwargs or kwargs["dtype"] is None:
+                kwargs["dtype"] = tensor_like.dtype
         return torch.zeros(*args, **kwargs).field_()
+
     zeros_like = zeros = identity
 
     def ones(*args, **kwargs):
@@ -136,13 +148,14 @@ class DisplacementField(torch.Tensor):
         """
         if len(args) > 0 and isinstance(args[0], torch.Tensor):
             tensor_like, *args = args
-            if 'device' not in kwargs or kwargs['device'] is None:
-                kwargs['device'] = tensor_like.device
-            if 'size' not in kwargs or kwargs['size'] is None:
-                kwargs['size'] = tensor_like.shape
-            if 'dtype' not in kwargs or kwargs['dtype'] is None:
-                kwargs['dtype'] = tensor_like.dtype
+            if "device" not in kwargs or kwargs["device"] is None:
+                kwargs["device"] = tensor_like.device
+            if "size" not in kwargs or kwargs["size"] is None:
+                kwargs["size"] = tensor_like.shape
+            if "dtype" not in kwargs or kwargs["dtype"] is None:
+                kwargs["dtype"] = tensor_like.dtype
         return torch.ones(*args, **kwargs).field_()
+
     ones_like = ones
 
     def rand(*args, **kwargs):
@@ -153,13 +166,14 @@ class DisplacementField(torch.Tensor):
         """
         if len(args) > 0 and isinstance(args[0], torch.Tensor):
             tensor_like, *args = args
-            if 'device' not in kwargs or kwargs['device'] is None:
-                kwargs['device'] = tensor_like.device
-            if 'size' not in kwargs or kwargs['size'] is None:
-                kwargs['size'] = tensor_like.shape
-            if 'dtype' not in kwargs or kwargs['dtype'] is None:
-                kwargs['dtype'] = tensor_like.dtype
+            if "device" not in kwargs or kwargs["device"] is None:
+                kwargs["device"] = tensor_like.device
+            if "size" not in kwargs or kwargs["size"] is None:
+                kwargs["size"] = tensor_like.shape
+            if "dtype" not in kwargs or kwargs["dtype"] is None:
+                kwargs["dtype"] = tensor_like.dtype
         return torch.rand(*args, **kwargs).field_()
+
     rand_like = rand
 
     @torch.no_grad()
@@ -178,10 +192,10 @@ class DisplacementField(torch.Tensor):
         field = rand_tensor * 2 - 1  # rescale to [-1, 1)
         field = field - field.identity_mapping()
         return field.requires_grad_(rand_tensor.requires_grad)
+
     rand_in_bounds_like = rand_in_bounds
 
-    def _get_parameters(tensor, shape=None, device=None, dtype=None,
-                        override=False):
+    def _get_parameters(tensor, shape=None, device=None, dtype=None, override=False):
         """Auxiliary function to deduce the right set of parameters to a tensor
         function.
         In particular, if `tensor` is a `torch.Tensor`, it uses those values.
@@ -192,23 +206,23 @@ class DisplacementField(torch.Tensor):
         """
         if isinstance(tensor, torch.Tensor):
             shape = shape if override and (shape is not None) else tensor.shape
-            device = (device if override and (device is not None)
-                      else tensor.device)
+            device = device if override and (device is not None) else tensor.device
             dtype = dtype if override and (dtype is not None) else tensor.dtype
         else:
             if device is None:
                 try:
                     device = torch.cuda.current_device()
                 except AssertionError:
-                    device = 'cpu'
+                    device = "cpu"
             if dtype is None:
                 dtype = torch.float
         if isinstance(shape, tuple):
             batch_dim = shape[0] if len(shape) > 3 else 1
             if len(shape) < 2:
-                raise ValueError("The shape must have at least two spatial "
-                                 "dimensions. Recieved shape {}."
-                                 .format(shape))
+                raise ValueError(
+                    "The shape must have at least two spatial "
+                    "dimensions. Recieved shape {}.".format(shape)
+                )
             while len(shape) < 4:
                 shape = (1,) + shape
         else:
@@ -216,25 +230,30 @@ class DisplacementField(torch.Tensor):
                 shape = torch.Size((1, 2, shape, shape))
                 batch_dim = 1
             except TypeError:
-                raise TypeError("'shape' must be an 'int', 'tuple', or "
-                                "'torch.Size'. Received '{}'"
-                                .format(type(shape).__qualname__))
+                raise TypeError(
+                    "'shape' must be an 'int', 'tuple', or "
+                    "'torch.Size'. Received '{}'".format(type(shape).__qualname__)
+                )
         device = torch.device(device)
         if dtype == torch.double:
-            tensor_type = (torch.DoubleTensor if device.type == 'cpu'
-                           else torch.cuda.DoubleTensor)
+            tensor_type = (
+                torch.DoubleTensor if device.type == "cpu" else torch.cuda.DoubleTensor
+            )
         elif dtype == torch.float:
-            tensor_type = (torch.FloatTensor if device.type == 'cpu'
-                           else torch.cuda.FloatTensor)
+            tensor_type = (
+                torch.FloatTensor if device.type == "cpu" else torch.cuda.FloatTensor
+            )
         else:
-            raise ValueError("The data type must be either torch.float or "
-                             "torch.double. Recieved {}.".format(dtype))
+            raise ValueError(
+                "The data type must be either torch.float or "
+                "torch.double. Recieved {}.".format(dtype)
+            )
         return {
-            'shape': shape,
-            'batch_dim': batch_dim,
-            'device': device,
-            'dtype': dtype,
-            'tensor_type': tensor_type
+            "shape": shape,
+            "batch_dim": batch_dim,
+            "device": device,
+            "dtype": dtype,
+            "tensor_type": tensor_type,
         }
 
     @torch.no_grad()
@@ -270,16 +289,16 @@ class DisplacementField(torch.Tensor):
         """
         # find the right set of parameters
         params = DisplacementField._get_parameters(size, size, device, dtype)
-        orig_shape, batch_dim, device, tensor_type = \
-            [params[key] for key in ('shape', 'batch_dim',
-                                     'device', 'tensor_type')]
-        id_theta = tensor_type([[[1., 0., 0.], [0., 1., 0.]]], device=device)
+        orig_shape, batch_dim, device, tensor_type = [
+            params[key] for key in ("shape", "batch_dim", "device", "tensor_type")
+        ]
+        id_theta = tensor_type([[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]], device=device)
         id_theta = id_theta.expand(batch_dim, *id_theta.shape[1:])
         Id = F.affine_grid(id_theta, orig_shape, align_corners=False)
         return Id.permute(0, 3, 1, 2).field_()  # move the components to 2nd position
 
     @classmethod
-    def affine_field(cls, aff, size, offset=(0., 0.), device=None, dtype=None):
+    def affine_field(cls, aff, size, offset=(0.0, 0.0), device=None, dtype=None):
         """Returns a displacement field for an affine transform within a bbox
 
         Args:
@@ -305,11 +324,13 @@ class DisplacementField(torch.Tensor):
             define the location in the source image that contribute to a pixel
             in the destination image.
         """
-        params = DisplacementField._get_parameters(aff, size, device, dtype,
-                                                   override=True)
-        device, dtype, tensor_type, size, batch_dim = \
-            [params[key] for key in ('device', 'dtype', 'tensor_type',
-                                     'shape', 'batch_dim')]
+        params = DisplacementField._get_parameters(
+            aff, size, device, dtype, override=True
+        )
+        device, dtype, tensor_type, size, batch_dim = [
+            params[key]
+            for key in ("device", "dtype", "tensor_type", "shape", "batch_dim")
+        ]
         if isinstance(aff, list):
             aff = tensor_type(aff, device=device)
         if aff.ndimension() == 2:
@@ -318,22 +339,26 @@ class DisplacementField(torch.Tensor):
         elif aff.ndimension() == 3:
             N = aff.shape[0]
         else:
-            raise ValueError("Expected 2 or 3-dimensional affine matrix. "
-                             "Received shape {}.".format(aff.shape))
+            raise ValueError(
+                "Expected 2 or 3-dimensional affine matrix. "
+                "Received shape {}.".format(aff.shape)
+            )
         if N == 1 and batch_dim > 1:
             aff = aff.expand(batch_dim, *aff.shape[1:])
             N = batch_dim
         if offset[0] != 0 or offset[1] != 0:
-            z = tensor_type([[0., 0., 1.]], device=device)
+            z = tensor_type([[0.0, 0.0, 1.0]], device=device)
             z = z.expand(N, *z.shape)
             A = torch.cat([aff, z], 1)
-            B = tensor_type([[1., 0., offset[0]],
-                             [0., 1., offset[1]],
-                             [0., 0., 1.]], device=device)
+            B = tensor_type(
+                [[1.0, 0.0, offset[0]], [0.0, 1.0, offset[1]], [0.0, 0.0, 1.0]],
+                device=device,
+            )
             B = B.expand(N, *B.shape)
-            Bi = tensor_type([[1., 0., -offset[0]],
-                              [0., 1., -offset[1]],
-                              [0., 0., 1.]], device=device)
+            Bi = tensor_type(
+                [[1.0, 0.0, -offset[0]], [0.0, 1.0, -offset[1]], [0.0, 0.0, 1.0]],
+                device=device,
+            )
             Bi = Bi.expand(N, *Bi.shape)
             aff = torch.mm(Bi, torch.mm(A, B))[:, :2]
         M = F.affine_grid(aff, size, align_corners=False)
@@ -379,7 +404,7 @@ class DisplacementField(torch.Tensor):
         since `df.is_identity()` is equivalent to `not df`.
         """
         if eps is None and magn_eps is None:
-            return (self == 0.).all()
+            return (self == 0.0).all()
         else:
             is_id = True
             if eps is not None:
@@ -390,6 +415,7 @@ class DisplacementField(torch.Tensor):
 
     def __bool__(self):
         return not self.is_identity().tensor_()
+
     __nonzero__ = __bool__
 
     def magnitude(self, keepdim=False):
@@ -476,7 +502,7 @@ class DisplacementField(torch.Tensor):
             `(N, 2, 1, 1)` if `keepdim` is `True`, containing the mean nonzero
             vector of each field
         """
-        mask = (self.magnitude(keepdim=True) > 0)
+        mask = self.magnitude(keepdim=True) > 0
         if keepdim:
             sum = self.sum(-1, keepdim=keepdim).sum(-2, keepdim=keepdim)
             count = mask.sum(-1, keepdim=keepdim).sum(-2, keepdim=keepdim)
@@ -498,8 +524,7 @@ class DisplacementField(torch.Tensor):
             vector of each field
         """
         if keepdim:
-            return (self.min(-1, keepdim=keepdim).values
-                        .min(-2, keepdim=keepdim).values)
+            return self.min(-1, keepdim=keepdim).values.min(-2, keepdim=keepdim).values
         else:
             return self.min(-1).values.min(-1).values
 
@@ -516,8 +541,7 @@ class DisplacementField(torch.Tensor):
             vector of each field
         """
         if keepdim:
-            return (self.max(-1, keepdim=keepdim).values
-                        .max(-2, keepdim=keepdim).values)
+            return self.max(-1, keepdim=keepdim).values.max(-2, keepdim=keepdim).values
         else:
             return self.max(-1).values.max(-1).values
 
@@ -630,7 +654,7 @@ class DisplacementField(torch.Tensor):
             size = self.shape
         if isinstance(size, tuple):
             size = size[-1]
-        return self.mapping().pixels(size) + (size - 1)/2
+        return self.mapping().pixels(size) + (size - 1) / 2
 
     def from_pixel_mapping(self, size=None):
         """Convert a mapping to a displacement field which contains the
@@ -652,7 +676,7 @@ class DisplacementField(torch.Tensor):
             size = self.shape
         if isinstance(size, tuple):
             size = size[-1]
-        return (self - (size - 1)/2).from_pixels(size).from_mapping()
+        return (self - (size - 1) / 2).from_pixels(size).from_mapping()
 
     # Aliases for the components of the displacent vectors
 
@@ -665,6 +689,7 @@ class DisplacementField(torch.Tensor):
     @x.setter
     def x(self, value):
         self[..., 0:1, :, :] = value
+
     j = x  # j & x are both aliases for the column component of the displacent
 
     @property
@@ -676,12 +701,13 @@ class DisplacementField(torch.Tensor):
     @y.setter
     def y(self, value):
         self[..., 1:2, :, :] = value
+
     i = y  # i & y are both aliases for the row component of the displacent
 
     # Functions for sampling, composing, mapping, warping
 
     @ensure_dimensions(ndimensions=4, arg_indices=(1, 0), reverse=True)
-    def sample(self, input, mode='bilinear', padding_mode='zeros'):
+    def sample(self, input, mode="bilinear", padding_mode="zeros"):
         r"""A wrapper for the PyTorch grid sampler to sample or warp and image
         by a displacent field.
 
@@ -722,13 +748,14 @@ class DisplacementField(torch.Tensor):
         """
         field = self + self.identity_mapping()
         field = field.permute(0, 2, 3, 1)  # move components to last position
-        out = F.grid_sample(input, field, mode=mode,
-                            padding_mode=padding_mode, align_corners=False)
+        out = F.grid_sample(
+            input, field, mode=mode, padding_mode=padding_mode, align_corners=False
+        )
         if not isinstance(input, DisplacementField):
             out.tensor_()
         return out
 
-    def compose_with(self, other, mode='bilinear'):
+    def compose_with(self, other, mode="bilinear"):
         r"""Compose this displacement field with another displacement field.
         If `f = self` and `g = other`, then this computes
         `f⚬g` such that `(f⚬g)(x) ~= f(g(x))` for any tensor `x`.
@@ -742,9 +769,9 @@ class DisplacementField(torch.Tensor):
         sampling twice, information is inevitably lost in the intermediate
         stage. Sampling with the composed field is therefore more precise.
         """
-        return self + self.sample(other, padding_mode='border')
+        return self + self.sample(other, padding_mode="border")
 
-    def __call__(self, x, mode='bilinear'):
+    def __call__(self, x, mode="bilinear"):
         """Syntactic sugar for `compose_with()` or `sample()`, depending on
         the type of the sampled tensor.
 
@@ -783,11 +810,12 @@ class DisplacementField(torch.Tensor):
         in other words, one mip level.
         """
         if mips is not None:
-            scale_factor = 2**mips
+            scale_factor = 2 ** mips
         if scale_factor == 1:
             return self
-        return F.interpolate(self, scale_factor=scale_factor,
-                             mode='bilinear', align_corners=False)
+        return F.interpolate(
+            self, scale_factor=scale_factor, mode="bilinear", align_corners=False
+        )
 
     @ensure_dimensions(ndimensions=4, arg_indices=(0), reverse=True)
     def down(self, mips=None, scale_factor=2):
@@ -797,11 +825,12 @@ class DisplacementField(torch.Tensor):
         in other words, one mip level.
         """
         if mips is not None:
-            scale_factor = 2**mips
+            scale_factor = 2 ** mips
         if scale_factor == 1:
             return self
-        return F.interpolate(self, scale_factor=1./scale_factor,
-                             mode='bilinear', align_corners=False)
+        return F.interpolate(
+            self, scale_factor=1.0 / scale_factor, mode="bilinear", align_corners=False
+        )
 
     # Displacement Field Inverses
 
@@ -907,11 +936,32 @@ class DisplacementField(torch.Tensor):
         return voting.vote(self, softmin_temp, blur_sigma, subset_size)
 
     @wraps(voting.vote)
-    def get_vote_weights_with_variances(self, var, softmin_temp=1, blur_sigma=1, 
-                                        subset_size=None):
-        return voting.get_vote_weights_with_variances(self, var, softmin_temp, blur_sigma, 
-                                                      subset_size)
+    def get_vote_weights_with_variances(
+        self, var, softmin_temp=1, blur_sigma=1, subset_size=None
+    ):
+        return voting.get_vote_weights_with_variances(
+            self, var, softmin_temp, blur_sigma, subset_size
+        )
 
     @wraps(voting.vote)
     def vote_with_variances(self, var, softmin_temp=1, blur_sigma=1, subset_size=None):
-        return voting.vote_with_variances(self, var, softmin_temp, blur_sigma, subset_size)
+        return voting.vote_with_variances(
+            self, var, softmin_temp, blur_sigma, subset_size
+        )
+
+    @wraps(voting.vote)
+    def get_vote_weights_with_distances(
+        self, distances, softmin_temp=1, blur_sigma=1, subset_size=None
+    ):
+        return voting.get_vote_weights_with_distances(
+            self, distances, softmin_temp, blur_sigma, subset_size
+        )
+
+    @wraps(voting.vote)
+    def vote_with_distances(
+        self, distances, softmin_temp=1, blur_sigma=1, subset_size=None
+    ):
+        return voting.vote_with_distances(
+            self, distances, softmin_temp, blur_sigma, subset_size
+        )
+

--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -887,5 +887,17 @@ class DisplacementField(torch.Tensor):
         return voting.gaussian_blur(self, sigma, kernel_size)
 
     @wraps(voting.vote)
+    def get_vote_shape(self):
+        return voting.get_vote_shape(self)
+
+    @wraps(voting.vote)
+    def get_vote_subsets(self):
+        return voting.get_vote_subsets(self)
+
+    @wraps(voting.vote)
+    def get_vote_weights(self, softmin_temp=1, blur_sigma=1):
+        return voting.get_vote_weights(self, softmin_temp, blur_sigma)
+
+    @wraps(voting.vote)
     def vote(self, softmin_temp=1, blur_sigma=1):
         return voting.vote(self, softmin_temp, blur_sigma)

--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -891,13 +891,13 @@ class DisplacementField(torch.Tensor):
         return voting.get_vote_shape(self)
 
     @wraps(voting.vote)
-    def get_vote_subsets(self):
-        return voting.get_vote_subsets(self)
+    def get_vote_subsets(self, subset_size=None):
+        return voting.get_vote_subsets(self, subset_size)
 
     @wraps(voting.vote)
-    def get_vote_weights(self, softmin_temp=1, blur_sigma=1):
-        return voting.get_vote_weights(self, softmin_temp, blur_sigma)
+    def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
+        return voting.get_vote_weights(self, softmin_temp, blur_sigma, subset_size)
 
     @wraps(voting.vote)
-    def vote(self, softmin_temp=1, blur_sigma=1):
-        return voting.vote(self, softmin_temp, blur_sigma)
+    def vote(self, softmin_temp=1, blur_sigma=1, subset_size=None):
+        return voting.vote(self, softmin_temp, blur_sigma, subset_size)

--- a/torchfields/fields.py
+++ b/torchfields/fields.py
@@ -891,6 +891,10 @@ class DisplacementField(torch.Tensor):
         return voting.get_vote_shape(self)
 
     @wraps(voting.vote)
+    def get_subset_size(self, subset_size=None):
+        return voting.get_subset_size(self, subset_size)
+
+    @wraps(voting.vote)
     def get_vote_subsets(self, subset_size=None):
         return voting.get_vote_subsets(self, subset_size)
 
@@ -901,3 +905,13 @@ class DisplacementField(torch.Tensor):
     @wraps(voting.vote)
     def vote(self, softmin_temp=1, blur_sigma=1, subset_size=None):
         return voting.vote(self, softmin_temp, blur_sigma, subset_size)
+
+    @wraps(voting.vote)
+    def get_vote_weights_with_variances(self, var, softmin_temp=1, blur_sigma=1, 
+                                        subset_size=None):
+        return voting.get_vote_weights_with_variances(self, var, softmin_temp, blur_sigma, 
+                                                      subset_size)
+
+    @wraps(voting.vote)
+    def vote_with_variances(self, var, softmin_temp=1, blur_sigma=1, subset_size=None):
+        return voting.vote_with_variances(self, var, softmin_temp, blur_sigma, subset_size)

--- a/torchfields/test_voting.py
+++ b/torchfields/test_voting.py
@@ -2,29 +2,67 @@ import pytest
 import torch
 import torchfields
 
+
 def test_vote_shape():
-    assert(False)
+    assert False
+
 
 def test_voting_subsets():
-    assert(False)
+    assert False
+
 
 def test_voting_weights():
-    assert(False)
+    assert False
+
 
 def test_vote():
-    assert(False)
+    assert False
+
 
 def test_vote_with_variances():
-    f = torch.zeros((2,2,1,1)).field()
+    f = torch.zeros((2, 2, 1, 1)).field()
     f[1] = 1
-    v = torch.zeros((2,1,1,1))
+    v = torch.zeros((2, 1, 1, 1))
     vf = f.vote_with_variances(var=v, softmin_temp=1, blur_sigma=0, subset_size=1)
-    tf = torch.ones((1,2,1,1)).field() / 2.
-    assert(torch.equal(tf, vf))
+    tf = torch.ones((1, 2, 1, 1)).field() / 2.0
+    assert torch.equal(tf, vf)
     v[1] = 1
     # softmin_temp root of (e^(-sqrt(2)/x))/(e^(-sqrt(2)/x)+e^(0/x))-0.25=0
     vf = f.vote_with_variances(var=v, softmin_temp=1.28727, blur_sigma=0, subset_size=1)
-    tf = torch.ones((1,2,1,1)).field() / 4.
-    assert(torch.allclose(tf, vf))
+    tf = torch.ones((1, 2, 1, 1)).field() / 4.0
+    assert torch.allclose(tf, vf)
 
-    
+
+def test_vote_with_distances():
+    f = torch.zeros((2, 2, 1, 1)).field()
+    f[1] = 1
+    d = torch.ones((2, 1, 1))
+    d[1] = 2
+    df = f.vote_with_distances(distances=d, softmin_temp=1, blur_sigma=0, subset_size=1)
+    tf = torch.ones((1, 2, 1, 1)).field() / 2.0
+    assert torch.equal(tf, df)
+    f = torch.zeros((2, 2, 1, 1)).field()
+    f[1] = 1
+    d = torch.ones((2, 1, 1))
+    d[1] = 2
+    df = f.get_vote_weights_with_distances(
+        distances=d, softmin_temp=1, blur_sigma=0, subset_size=2
+    )
+    tf = torch.ones((2, 1, 1)) / 3.0
+    tf[0] *= 2.0
+    assert torch.equal(tf, df)
+    f = torch.zeros((3, 2, 1, 1)).field()
+    f[1] = 1
+    f[2] = 1.2
+    d = torch.ones((3, 1, 1))
+    d[1] = 2
+    d[2] = 3
+    df = f.vote_with_distances(
+        distances=d, softmin_temp=0.01, blur_sigma=0, subset_size=2
+    )
+    tf = (
+        torch.ones((1, 2, 1, 1)).field() * 3 / 5.0
+        + torch.ones((1, 2, 1, 1)).field() * 1.2 * 2 / 5.0
+    )
+    assert torch.allclose(tf, df)
+

--- a/torchfields/test_voting.py
+++ b/torchfields/test_voting.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+import torchfields
+
+def test_vote_shape():
+    assert(False)
+
+def test_voting_subsets():
+    assert(False)
+
+def test_voting_weights():
+    assert(False)
+
+def test_vote():
+    assert(False)
+
+def test_vote_with_variances():
+    f = torch.zeros((2,2,1,1)).field()
+    f[1] = 1
+    v = torch.zeros((2,1,1,1))
+    vf = f.vote_with_variances(var=v, softmin_temp=1, blur_sigma=0, subset_size=1)
+    tf = torch.ones((1,2,1,1)).field() / 2.
+    assert(torch.equal(tf, vf))
+    v[1] = 1
+    # softmin_temp root of (e^(-sqrt(2)/x))/(e^(-sqrt(2)/x)+e^(0/x))-0.25=0
+    vf = f.vote_with_variances(var=v, softmin_temp=1.28727, blur_sigma=0, subset_size=1)
+    tf = torch.ones((1,2,1,1)).field() / 4.
+    assert(torch.allclose(tf, vf))
+
+    

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -3,7 +3,7 @@ import torch.nn.functional as F
 
 
 ############################
-# Vector voting implemtation
+# Vector vote implemtation
 ############################
 
 def gaussian_blur(self, sigma=1, kernel_size=5):
@@ -27,6 +27,73 @@ def gaussian_blur(self, sigma=1, kernel_size=5):
     kernel = kernel.expand(2, 1, *kernel.shape)
     return F.conv2d(padded, weight=kernel, groups=2)
 
+def get_vote_shape(self):
+    """Consistently split shape into N fields & shape of field
+    """
+    n, _, *shape = self.shape
+    return n, shape
+
+def get_vote_subsets(self):
+    """Compute list of majority subsets to use in vote
+    """
+    n, _ = self.get_vote_shape()
+    m = (n + 1) // 2  # smallest number that constututes a majority
+    from itertools import combinations
+    mtuples = list(combinations(range(n), m))
+    return mtuples
+
+def get_vote_weights(self, softmin_temp=1, blur_sigma=1):
+    """Calculate softmin weights for batch of displacement fields, indicating 
+    which fields should be considered consensus.
+
+    Args:
+        self: DisplacementField of shape (N, 2, H, W)
+        softmin_temp (float): temperature of softmin to use
+        blur_sigma (float): std dev of the Gaussian kernel by which to blur
+            the softmin inputs. Note that the outputs are not blurred.
+            None or 0 means no blurring.
+
+    Returns:
+        softmin numerator (torch.Tensor): (N, 1, H, W)
+        softmin denominator (torch. Tensor): (N, 1, H, W)
+    """
+    from itertools import combinations
+    if self.ndimension() != 4:
+        raise ValueError('Vector vote is only implemented on '
+                         'displacement fields with 4 dimensions. '
+                         'The input has {}.'.format(self.ndimension()))
+    n, shape = self.get_vote_shape()
+    if n == 1:
+        return self 
+    elif n % 2 == 0:
+        raise ValueError('Cannot vetor vote on an even number of '
+                         'displacement fields: {}'.format(n))
+    blurred = self.gaussian_blur(sigma=blur_sigma) if blur_sigma else self
+    mtuples = self.get_vote_subsets()
+
+    # compute distances for all pairs of fields
+    dists = torch.zeros((n, n, *shape)).to(device=blurred.device)
+    for i in range(n):
+        for j in range(i):
+            dists[i, j] = dists[j, i] \
+                = blurred[i].distance(blurred[j])
+
+    # compute mean distance for all majority tuples
+    mtuple_avg = []
+    for mtuple in mtuples:
+        delta = torch.stack([
+            dists[i, j] for i, j in combinations(mtuple, 2)
+        ]).mean(dim=0)
+        mtuple_avg.append(delta)
+    mavg = torch.stack(mtuple_avg)
+
+    # compute weights for mtuples: smaller mean distance -> higher weight
+    # computing softmin explicitly for access to numerator & denominator
+    # equivalent to:
+    # (-mavg/softmin_temp).softmax(dim=0) == weights_num / weight_den
+    weights_num = torch.exp(-mavg/softmin_temp)
+    weights_den = weights_num.sum(dim=0, keepdim=True)
+    return weights_num, weights_den
 
 def vote(self, softmin_temp=1, blur_sigma=1):
     """Produce a single, consensus displacement field from a batch of
@@ -46,66 +113,19 @@ def vote(self, softmin_temp=1, blur_sigma=1):
 
     Returns:
         DisplacementField of shape (1, 2, H, W) containing the vector
-        voting result
+        vote result
     """
-    field_weights = get_field_weights(self, 
-                                      softmin_temp=softmin_temp,
-                                      blur_sigma=blur_sigma)
-    partition = field_weights.sum(dim=0, keepdim=True)
-    field_weights = field_weights / partition
-    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
-
-def get_field_weights(field, softmin_temp=1, blur_sigma=1):
-    """Calculate softmin weights for set of fields, indicating which fields
-    should be considered consensus.
-
-    Args:
-        field: DisplacementField of shape (N, 2, H, W)
-        softmin_temp (float): temperature of softmin to use
-        blur_sigma (float): std dev of the Gaussian kernel by which to blur
-            the softmin inputs. Note that the outputs are not blurred.
-            None or 0 means no blurring.
-
-    Returns:
-        torch.Tensor of shape (N, 1, H, W) containing the field weights 
-    """
-    from itertools import combinations
-    if field.ndimension() != 4:
-        raise ValueError('Vector voting is only implemented on '
-                         'displacement fields with 4 dimensions. '
-                         'The input has {}.'.format(field.ndimension()))
-    n, _two_, *shape = field.shape
-    if n == 1:
-        return field
-    elif n % 2 == 0:
-        raise ValueError('Cannot vetor vote on an even number of '
-                         'displacement fields: {}'.format(n))
-    m = (n + 1) // 2  # smallest number that constututes a majority
-    blurred = field.gaussian_blur(sigma=blur_sigma) if blur_sigma else field
-
-    # compute distances for all pairs of fields
-    dists = torch.zeros((n, n, *shape)).to(device=blurred.device)
-    for i in range(n):
-        for j in range(i):
-            dists[i, j] = dists[j, i] \
-                = blurred[i].distance(blurred[j])
-
-    # compute mean distance for all m-tuples
-    mtuples = list(combinations(range(n), m))
-    mtuple_avg = []
-    for mtuple in mtuples:
-        delta = torch.stack([
-            dists[i, j] for i, j in combinations(mtuple, 2)
-        ]).mean(dim=0)
-        mtuple_avg.append(delta)
-    mavg = torch.stack(mtuple_avg)
-
-    # compute weights for mtuples: smaller mean distance -> higher weight
-    mt_weights = (-mavg/softmin_temp).softmax(dim=0)
-
+    n, shape = self.get_vote_shape()
+    mtuples = self.get_vote_subsets()
+    mt_num , mt_den = self.get_vote_weights(softmin_temp=softmin_temp,
+                                              blur_sigma=blur_sigma)
+    mt_weights = mt_num / mt_den 
     # assign mtuple weights back to individual fields
     field_weights = torch.zeros((n, *shape)).to(device=mt_weights.device)
     for i, mtuple in enumerate(mtuples):
         for j in mtuple:
             field_weights[j] += mt_weights[i]
-    return field_weights
+    # rather than use m, prefer sum for sum precision
+    elements_per_subset = field_weights.sum(dim=0, keepdim=True)
+    field_weights = field_weights / elements_per_subset
+    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -66,7 +66,7 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
                          'The input has {}.'.format(self.ndimension()))
     n, shape = self.get_vote_shape()
     if n == 1:
-        return self 
+        return torch.ones((1, *shape)) 
     # elif n % 2 == 0:
     #     raise ValueError('Cannot vetor vote on an even number of '
     #                      'displacement fields: {}'.format(n))

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -66,7 +66,9 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
                          'The input has {}.'.format(self.ndimension()))
     n, shape = self.get_vote_shape()
     if n == 1:
-        return torch.ones((1, *shape)) 
+        return torch.ones((1, *shape)).to(self)
+    elif n == 2:
+        return torch.ones((1, *shape)).to(self) / 2
     # elif n % 2 == 0:
     #     raise ValueError('Cannot vetor vote on an even number of '
     #                      'displacement fields: {}'.format(n))

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -6,32 +6,36 @@ import torch.nn.functional as F
 # Vector vote implemtation
 ############################
 
+
 def gaussian_blur(self, sigma=1, kernel_size=5):
     """Gausssian blur the displacement field to reduce any unsmoothness
     Adapted from https://bit.ly/2JO7CCP
     """
     import math
+
     if sigma == 0:
         return self.clone()
     pad = (kernel_size - 1) // 2
     if kernel_size % 2 == 0:
-        pad = (pad, pad+1, pad, pad+1)
+        pad = (pad, pad + 1, pad, pad + 1)
     else:
-        pad = (pad,)*4
-    padded = F.pad(self, pad, mode='reflect')
+        pad = (pad,) * 4
+    padded = F.pad(self, pad, mode="reflect")
     mu = (kernel_size - 1) / 2
-    x = torch.stack(torch.meshgrid([torch.arange(kernel_size).to(self)]*2))
-    kernel = torch.exp((-((x - mu) / sigma) ** 2) / 2)
-    kernel = kernel.prod(dim=0) / (2 * math.pi * sigma**2)
+    x = torch.stack(torch.meshgrid([torch.arange(kernel_size).to(self)] * 2))
+    kernel = torch.exp((-(((x - mu) / sigma) ** 2)) / 2)
+    kernel = kernel.prod(dim=0) / (2 * math.pi * sigma ** 2)
     kernel = kernel / kernel.sum()  # renormalize to get unit product
     kernel = kernel.expand(2, 1, *kernel.shape)
     return F.conv2d(padded, weight=kernel, groups=2)
+
 
 def get_vote_shape(self):
     """Consistently split shape into N fields & shape of field
     """
     n, _, *shape = self.shape
     return n, shape
+
 
 def get_subset_size(self, subset_size=None):
     """Compute smallest majority of self is subset_size not set
@@ -42,14 +46,17 @@ def get_subset_size(self, subset_size=None):
         m = subset_size
     return m
 
+
 def get_vote_subsets(self, subset_size=None):
     """Compute list of majority subsets to use in vote
     """
     n, _ = self.get_vote_shape()
     m = self.get_subset_size(subset_size=subset_size)
     from itertools import combinations
+
     subset_tuples = list(combinations(range(n), m))
     return subset_tuples
+
 
 def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
     """Calculate per field weights for batch of displacement fields, indicating 
@@ -67,10 +74,13 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
         per field weight (torch.Tensor): (N, 1, H, W)
     """
     from itertools import combinations
+
     if self.ndimension() != 4:
-        raise ValueError('Vector vote is only implemented on '
-                         'displacement fields with 4 dimensions. '
-                         'The input has {}.'.format(self.ndimension()))
+        raise ValueError(
+            "Vector vote is only implemented on "
+            "displacement fields with 4 dimensions. "
+            "The input has {}.".format(self.ndimension())
+        )
     n, shape = self.get_vote_shape()
     subset_size = self.get_subset_size(subset_size=subset_size)
     if n == 1:
@@ -87,15 +97,14 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
     dists = torch.zeros((n, n, *shape)).to(device=blurred.device)
     for i in range(n):
         for j in range(i):
-            dists[i, j] = dists[j, i] \
-                = blurred[i].distance(blurred[j])
+            dists[i, j] = dists[j, i] = blurred[i].distance(blurred[j])
 
     # compute mean distance for all majority tuples
     mtuple_avg = []
     for mtuple in mtuples:
-        delta = torch.stack([
-            dists[i, j] for i, j in combinations(mtuple, 2)
-        ]).mean(dim=0)
+        delta = torch.stack([dists[i, j] for i, j in combinations(mtuple, 2)]).mean(
+            dim=0
+        )
         mtuple_avg.append(delta)
     mavg = torch.stack(mtuple_avg)
 
@@ -103,10 +112,10 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
     # computing softmin explicitly for access to numerator & denominator
     # equivalent to:
     # (-mavg/softmin_temp).softmax(dim=0) == mt_weights_num / mt_weights_den
-    mt_weights_num = torch.exp(-mavg/softmin_temp)
+    mt_weights_num = torch.exp(-mavg / softmin_temp)
     mt_weights_den = mt_weights_num.sum(dim=0, keepdim=True)
 
-    mt_weights = mt_weights_num / mt_weights_den 
+    mt_weights = mt_weights_num / mt_weights_den
     # assign mtuple weights back to individual fields
     field_weights = torch.zeros((n, *shape)).to(device=mt_weights.device)
     for i, mtuple in enumerate(mtuples):
@@ -116,6 +125,7 @@ def get_vote_weights(self, softmin_temp=1, blur_sigma=1, subset_size=None):
     elements_per_subset = field_weights.sum(dim=0, keepdim=True)
     field_weights = field_weights / elements_per_subset
     return field_weights
+
 
 def vote(self, softmin_temp=1, blur_sigma=1, subset_size=None):
     """Produce a single, consensus displacement field from a batch of
@@ -138,13 +148,116 @@ def vote(self, softmin_temp=1, blur_sigma=1, subset_size=None):
         DisplacementField of shape (1, 2, H, W) containing the vector
         vote result
     """
-    field_weights = self.get_vote_weights(softmin_temp=softmin_temp,
-                                              blur_sigma=blur_sigma,
-                                              subset_size=subset_size)
+    field_weights = self.get_vote_weights(
+        softmin_temp=softmin_temp, blur_sigma=blur_sigma, subset_size=subset_size
+    )
     return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
 
-def get_vote_weights_with_variances(self, var, softmin_temp=1, 
-                                          blur_sigma=1, subset_size=None):
+
+def get_vote_weights_with_distances(
+    self, distances, softmin_temp=1, blur_sigma=1, subset_size=None
+):
+    """Calculate consensus field from batch of displacement fields along with distances.
+    Voting proceeds as normal, until it comes time to distribute the weight of each
+    subset amongst its constitute vectors. The distribution is now based on the 
+    distances of each vector, with distances further away making a vector contribute
+    less to consensus than nearer distance vectors in the subset.
+
+    Weights should be proportional to get_vote_weights if distances are identical.
+
+    Args:
+        self: DisplacementField of shape (N, 2, H, W)
+        distances: Tensor of shape (N, H, W)
+        softmin_temp (float): temperature of softmin to use
+        blur_sigma (float): std dev of the Gaussian kernel by which to blur
+            the softmin inputs. Note that the outputs are not blurred.
+            None or 0 means no blurring.
+        subset_size (int): number of members to each set for comparison
+
+    Returns:
+        per field weight (torch.Tensor): (N, 1, H, W)
+    """
+    from itertools import combinations
+
+    if self.ndimension() != 4:
+        raise ValueError(
+            "Vector vote is only implemented on "
+            "displacement fields with 4 dimensions. "
+            "The input has {}.".format(self.ndimension())
+        )
+    n, shape = self.get_vote_shape()
+    subset_size = self.get_subset_size(subset_size=subset_size)
+    if n == 1:
+        return torch.ones((1, *shape)).to(self)
+    blurred = self.gaussian_blur(sigma=blur_sigma) if blur_sigma else self
+    # distances = distances.gaussian_blur(sigma=blur_sigma) if blur_sigma else distances
+    subset_tuples = self.get_vote_subsets(subset_size=subset_size)
+
+    # compute mean of mixture distribution for all subset tuples
+    subset_avg = {}
+    for subset in subset_tuples:
+        s_avg = torch.stack([blurred[i] for i in subset]).mean(dim=0)
+        subset_avg[subset] = s_avg
+
+    # compute standard deviations of mixture distribution for all subset tuples with var=0
+    subset_std = []
+    for subset in subset_tuples:
+        s_moment_sum = torch.stack([blurred[i].pow(2) for i in subset])
+        s_var = (s_moment_sum - subset_avg[subset].pow(2)).mean(dim=0)
+        subset_std.append(s_var.abs().sqrt())
+    subset_std_dist = torch.stack(subset_std).pow(2).sum(dim=-3).sqrt()
+
+    # compute weights for subset_tuples: smaller variance -> higher weight
+    # computing softmin explicitly for access to numerator & denominator
+    # equivalent to:
+    # subset_weights == (-subset_std_dist/softmin_temp).softmax(dim=0)
+    subset_weights_num = torch.exp(-subset_std_dist / softmin_temp)
+    subset_weights_den = subset_weights_num.sum(dim=0, keepdim=True)
+
+    subset_weights = subset_weights_num / subset_weights_den
+    # assign subset weights back to individual fields
+    # use distances to partition the weights: larger distance -> less weight
+    field_weights = torch.zeros((n, *shape)).to(device=subset_weights.device)
+    for i, subset in enumerate(subset_tuples):
+        dists = distances[subset, ...]
+        weights = (1.0 / dists) * (1.0 / (1.0 / dists).sum(dim=0))
+        for k, j in enumerate(subset):
+            field_weights[j] += subset_weights[i] * weights[k]
+    return field_weights
+
+
+def vote_with_distances(
+    self, distances, softmin_temp=1, blur_sigma=1, subset_size=None
+):
+    """Produce a single, consensus displacement field from a batch of
+    displacement fields along with a distance measure that weights further
+    fields less in the consensus.
+
+    Args:
+        self: DisplacementField of shape (N, 2, H, W)
+        distances: Tensor of shape (N, 1, H, W)
+        softmin_temp (float): temperature of softmin to use
+        blur_sigma (float): std dev of the Gaussian kernel by which to blur
+            the softmin inputs. Note that the outputs are not blurred.
+            None or 0 means no blurring.
+        subset_size (int): number of members to each subset
+
+    Returns:
+        DisplacementField of shape (1, 2, H, W) containing the vector
+        vote result
+    """
+    field_weights = self.get_vote_weights_with_distances(
+        softmin_temp=softmin_temp,
+        distances=distances,
+        blur_sigma=blur_sigma,
+        subset_size=subset_size,
+    )
+    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
+
+
+def get_vote_weights_with_variances(
+    self, var, softmin_temp=1, blur_sigma=1, subset_size=None
+):
     """Calculate consensus field from batch of displacement fields along with variances.
     Each vector within self is treated as the mean of a distribution with isotropic 
     variance for the corresponding location in variances. A subset of vectors is
@@ -166,10 +279,13 @@ def get_vote_weights_with_variances(self, var, softmin_temp=1,
         per field weight (torch.Tensor): (N, 1, H, W)
     """
     from itertools import combinations
+
     if self.ndimension() != 4:
-        raise ValueError('Vector vote is only implemented on '
-                         'displacement fields with 4 dimensions. '
-                         'The input has {}.'.format(self.ndimension()))
+        raise ValueError(
+            "Vector vote is only implemented on "
+            "displacement fields with 4 dimensions. "
+            "The input has {}.".format(self.ndimension())
+        )
     n, shape = self.get_vote_shape()
     subset_size = self.get_subset_size(subset_size=subset_size)
     if n == 1:
@@ -199,10 +315,10 @@ def get_vote_weights_with_variances(self, var, softmin_temp=1,
     # computing softmin explicitly for access to numerator & denominator
     # equivalent to:
     # subset_weights == (-subset_std_dist/softmin_temp).softmax(dim=0)
-    subset_weights_num = torch.exp(-subset_std_dist/softmin_temp)
+    subset_weights_num = torch.exp(-subset_std_dist / softmin_temp)
     subset_weights_den = subset_weights_num.sum(dim=0, keepdim=True)
 
-    subset_weights = subset_weights_num / subset_weights_den 
+    subset_weights = subset_weights_num / subset_weights_den
     # assign subset weights back to individual fields
     field_weights = torch.zeros((n, *shape)).to(device=subset_weights.device)
     for i, subset in enumerate(subset_tuples):
@@ -212,6 +328,7 @@ def get_vote_weights_with_variances(self, var, softmin_temp=1,
     elements_per_subset = field_weights.sum(dim=0, keepdim=True)
     field_weights = field_weights / elements_per_subset
     return field_weights
+
 
 def vote_with_variances(self, var, softmin_temp=1, blur_sigma=1, subset_size=None):
     """Produce a single, consensus displacement field from a batch of
@@ -230,8 +347,10 @@ def vote_with_variances(self, var, softmin_temp=1, blur_sigma=1, subset_size=Non
         DisplacementField of shape (1, 2, H, W) containing the vector
         vote result
     """
-    field_weights = self.get_vote_weights_with_variances(softmin_temp=softmin_temp,
-                                              var=var,
-                                              blur_sigma=blur_sigma,
-                                              subset_size=subset_size)
+    field_weights = self.get_vote_weights_with_variances(
+        softmin_temp=softmin_temp,
+        var=var,
+        blur_sigma=blur_sigma,
+        subset_size=subset_size,
+    )
     return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)

--- a/torchfields/voting.py
+++ b/torchfields/voting.py
@@ -48,19 +48,40 @@ def vote(self, softmin_temp=1, blur_sigma=1):
         DisplacementField of shape (1, 2, H, W) containing the vector
         voting result
     """
+    field_weights = get_field_weights(self, 
+                                      softmin_temp=softmin_temp,
+                                      blur_sigma=blur_sigma)
+    partition = field_weights.sum(dim=0, keepdim=True)
+    field_weights = field_weights / partition
+    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
+
+def get_field_weights(field, softmin_temp=1, blur_sigma=1):
+    """Calculate softmin weights for set of fields, indicating which fields
+    should be considered consensus.
+
+    Args:
+        field: DisplacementField of shape (N, 2, H, W)
+        softmin_temp (float): temperature of softmin to use
+        blur_sigma (float): std dev of the Gaussian kernel by which to blur
+            the softmin inputs. Note that the outputs are not blurred.
+            None or 0 means no blurring.
+
+    Returns:
+        torch.Tensor of shape (N, 1, H, W) containing the field weights 
+    """
     from itertools import combinations
-    if self.ndimension() != 4:
+    if field.ndimension() != 4:
         raise ValueError('Vector voting is only implemented on '
                          'displacement fields with 4 dimensions. '
-                         'The input has {}.'.format(self.ndimension()))
-    n, _two_, *shape = self.shape
+                         'The input has {}.'.format(field.ndimension()))
+    n, _two_, *shape = field.shape
     if n == 1:
-        return self
+        return field
     elif n % 2 == 0:
         raise ValueError('Cannot vetor vote on an even number of '
                          'displacement fields: {}'.format(n))
     m = (n + 1) // 2  # smallest number that constututes a majority
-    blurred = self.gaussian_blur(sigma=blur_sigma) if blur_sigma else self
+    blurred = field.gaussian_blur(sigma=blur_sigma) if blur_sigma else field
 
     # compute distances for all pairs of fields
     dists = torch.zeros((n, n, *shape)).to(device=blurred.device)
@@ -87,6 +108,4 @@ def vote(self, softmin_temp=1, blur_sigma=1):
     for i, mtuple in enumerate(mtuples):
         for j in mtuple:
             field_weights[j] += mt_weights[i]
-    field_weights = field_weights / field_weights.sum(dim=0, keepdim=True)
-
-    return (self * field_weights.unsqueeze(-3)).sum(dim=0, keepdim=True)
+    return field_weights


### PR DESCRIPTION
Similar to voting-uncertainty, `vote_with_distances` takes a set of distances per vector that will dictate how much each vector will contribute to the final consensus. Voting proceeds along the standard method, then the weight for each subset is distributed based on the distance of each vector in the subset, with vectors that have smaller distances getting more of the weight.

This is useful for voting during sequential alignment, where displacement fields generated to nearer sections tend to be more accurate than displacement fields further away.

This method could be used in addition to `vote_with_variances`, but we can address that when the need arises.