### PR TITLE
feat(use_identity_mapping_cache): caching identity_mapping() results

### DIFF
--- a/torchfields/__init__.py
+++ b/torchfields/__init__.py
@@ -1,4 +1,5 @@
 import torch
 from .fields import DisplacementField as Field
+from .fields import set_identity_mapping_cache
 
 torch.Field = Field


### PR DESCRIPTION
Adding class method to enable/disable caching for `identity_mapping()` calls based on `shape`, `device` and `dtype` of the _resulting_ identity field. Default is `False`.

Wasn't sure if I should force `clone` the fields found in cache, or leave it to the user if required... torchfield itself does not modify the identities in place in any of the current methods.
For now, I decided to skip clone to avoid needless copies, and left a note in the class method as well as the `identity_mapping()` call.